### PR TITLE
Publish Empty Radar Frames

### DIFF
--- a/ainstein_radar_drivers/launch/o79_can_node.launch
+++ b/ainstein_radar_drivers/launch/o79_can_node.launch
@@ -1,11 +1,13 @@
 <launch>
+  <!-- declare args to be passed in -->
+  <arg name="can_id_arg" default="0x18FFB24D"/>
 
   <node name="socketcan_bridge" pkg="socketcan_bridge" type="socketcan_bridge_node"  required="true" >
     <param name="can_device" value="can0" />
   </node>
-  
+
   <node name="o79_can" pkg="ainstein_radar_drivers" type="o79_can_node" required="true" output="screen" >
-    <param name="can_id" value="0x18FFB24D" />
+    <param name="can_id" value="$(arg can_id_arg)" />
   </node>
 
 </launch>

--- a/ainstein_radar_drivers/launch/o79_udp_node.launch
+++ b/ainstein_radar_drivers/launch/o79_udp_node.launch
@@ -1,10 +1,14 @@
 <launch>
+  <!-- declare args to be passed in -->
+  <arg name="radar_ip_arg" default="10.0.0.10"/>
+  <arg name="host_ip_arg" default="10.0.0.75"/>
+  <arg name="host_port_arg" default="1024" />
 
   <node name="o79_udp" pkg="ainstein_radar_drivers" type="o79_udp_node" output="screen" required="true" >
     <param name="frame_id" value="map" />
-    <param name="host_ip" value="10.0.0.75" />
-    <param name="host_port" value="1024" />
-    <param name="radar_ip" value="10.0.0.10" />
+    <param name="host_ip" value="$(arg host_ip_arg)" />
+    <param name="host_port" value="$(arg host_port_arg)" />
+    <param name="radar_ip" value="$(arg radar_ip_arg)" />
     <param name="radar_port" value="7" />
     <param name="publish_raw_cloud" value="true" />
     <param name="publish_tracked_cloud" value="false" />

--- a/ainstein_radar_drivers/src/radar_driver_o79_udp.cpp
+++ b/ainstein_radar_drivers/src/radar_driver_o79_udp.cpp
@@ -255,6 +255,13 @@ namespace ainstein_radar_drivers
 
 		    targets_tracked.push_back( target );
 		  }
+        if( targets_tracked.size() == 0 )
+        {
+          // no targets were received; push back some dummy data so that an
+          // empty target frame will be sent
+          target.id = -1;
+          targets_tracked.push_back( target );
+        }
 	      }
 	  }
 	else if( buffer_[0] == RadarDriverO79UDP::msg_id_raw_targets )

--- a/ainstein_radar_drivers/src/radar_driver_o79_udp.cpp
+++ b/ainstein_radar_drivers/src/radar_driver_o79_udp.cpp
@@ -283,6 +283,13 @@ namespace ainstein_radar_drivers
 
 		targets.push_back( target );
 	      }
+      if( targets.size() == 0 )
+      {
+        // no targets were received; push back some dummy data so that an
+        // empty target frame will be sent
+        target.id = -1;
+        targets.push_back( target );
+      }
 	  }
 	else if( buffer_[0] == RadarDriverO79UDP::msg_id_bounding_boxes )
 	  {

--- a/ainstein_radar_drivers/src/radar_interface_o79_can.cpp
+++ b/ainstein_radar_drivers/src/radar_interface_o79_can.cpp
@@ -79,14 +79,10 @@ namespace ainstein_radar_drivers
 	else if( msg.data[0]==0xFF && msg.data[1]==0xFF && msg.data[2]==0xFF && msg.data[3]==0xFF )
 	  {
 	    ROS_DEBUG( "received stop frame from radar" );
-	    if( radar_data_msg_ptr_raw_->targets.size() > 0 )
-	      {
-		pub_radar_data_raw_.publish( radar_data_msg_ptr_raw_ );
-	      }
-	    if( radar_data_msg_ptr_tracked_->targets.size() > 0 )
-	      {
-		pub_radar_data_tracked_.publish( radar_data_msg_ptr_tracked_ );
-	      }
+      // Publish raw and tracked frames even if no targets are received so that the display will
+      // clear if there are no targets
+		  pub_radar_data_raw_.publish( radar_data_msg_ptr_raw_ );
+		  pub_radar_data_tracked_.publish( radar_data_msg_ptr_tracked_ );
 	  }
 	// Parse out raw target data messages:
 	else if( msg.data[0] == 0x00 )

--- a/ainstein_radar_drivers/src/radar_interface_o79_udp.cpp
+++ b/ainstein_radar_drivers/src/radar_interface_o79_udp.cpp
@@ -151,7 +151,10 @@ void RadarInterfaceO79UDP::mainLoop(void)
 	      radar_data_msg_ptr_raw_->targets.clear();
 	      for( const auto &t : targets_raw )
 		{
-		  radar_data_msg_ptr_raw_->targets.push_back( targetToROSMsg( t ) );
+			if (t.id >= 0)
+			{
+		  	radar_data_msg_ptr_raw_->targets.push_back( targetToROSMsg( t ) );
+			}
 		}
 
 	      // Publish the raw target data:
@@ -163,7 +166,7 @@ void RadarInterfaceO79UDP::mainLoop(void)
 		  ainstein_radar_filters::data_conversions::radarTargetArrayToROSCloud( *radar_data_msg_ptr_raw_, *cloud_msg_ptr_raw_ );
 		  pub_cloud_raw_.publish( cloud_msg_ptr_raw_ );
 		}
-	      
+
 	    }
 
 	  if( targets_tracked.size() > 0 )

--- a/ainstein_radar_drivers/src/radar_interface_o79_udp.cpp
+++ b/ainstein_radar_drivers/src/radar_interface_o79_udp.cpp
@@ -176,7 +176,10 @@ void RadarInterfaceO79UDP::mainLoop(void)
 	      radar_data_msg_ptr_tracked_->targets.clear();
 	      for( const auto &t : targets_tracked )
 		{
-		  radar_data_msg_ptr_tracked_->targets.push_back( targetToROSMsg( t ) );
+			if (t.id >= 0)
+			{
+				radar_data_msg_ptr_tracked_->targets.push_back( targetToROSMsg( t ) );
+			}
 		}
 
 	      // Publish the tracked target data:


### PR DESCRIPTION
Publish frames that contain no valid target data if UDP or CAN messages are received without any target data. This has the effect of clearing the RViz display when the radar is running, but detects no targets. Previously, the display would retain the last valid targets sent during this condition.