### PR TITLE
Add USB camera launch file and rviz config

### DIFF
--- a/ainstein_radar_drivers/launch/usb_cam.launch
+++ b/ainstein_radar_drivers/launch/usb_cam.launch
@@ -1,0 +1,17 @@
+<launch>
+
+  <machine name="localhost" address="localhost" default="true" />
+
+  <arg name="machine" default="localhost" />
+
+  <node machine="$(arg machine)" name="usb_cam" pkg="usb_cam" type="usb_cam_node" output="screen" required="false" >
+    <param name="video_device" value="/dev/video2" />
+    <param name="image_width" value="320" />
+    <param name="image_height" value="240" />
+    <param name="framerate" value="10" />
+    <param name="pixel_format" value="yuyv" />
+    <param name="camera_frame_id" value="usb_cam" />
+    <param name="io_method" value="mmap"/>
+  </node>
+
+</launch>

--- a/ainstein_radar_drivers/rviz/o79.rviz
+++ b/ainstein_radar_drivers/rviz/o79.rviz
@@ -1,14 +1,13 @@
 Panels:
   - Class: rviz/Displays
-    Help Height: 78
+    Help Height: 70
     Name: Displays
     Property Tree Widget:
       Expanded:
         - /O-79 UDP1
         - /O-79 CAN1
-        - /Cartesian_Objects_CAN1
       Splitter Ratio: 0.5
-    Tree Height: 484
+    Tree Height: 213
   - Class: rviz/Selection
     Name: Selection
   - Class: rviz/Tool Properties
@@ -27,7 +26,7 @@ Panels:
     Experimental: false
     Name: Time
     SyncMode: 0
-    SyncSource: ""
+    SyncSource: Image
 Preferences:
   PromptSaveOnExit: true
 Toolbars:
@@ -65,24 +64,6 @@ Visualization Manager:
       Displays:
         - Alpha: 1
           Class: ainstein_radar_rviz_plugins/RadarTargetArray
-          Color: 0; 255; 0
-          Color Method: Flat
-          Enabled: true
-          Info Text Height: 0.05000000074505806
-          Max Range: 100
-          Min Range: 0
-          Name: Tracked Targets
-          Number of Scans: 1
-          Queue Size: 10
-          Scale: 0.5
-          Shape: Sphere
-          Show Info: false
-          Show Speed: true
-          Topic: /o79_udp/targets/tracked
-          Unreliable: false
-          Value: true
-        - Alpha: 1
-          Class: ainstein_radar_rviz_plugins/RadarTargetArray
           Color: 0; 0; 255
           Color Method: Flat
           Enabled: true
@@ -108,6 +89,18 @@ Visualization Manager:
           Topic: /o79_udp/boxes
           Unreliable: false
           Value: true
+        - Alpha: 1
+          Class: ainstein_radar_rviz_plugins/RadarTrackedObjectArray
+          Color: 255; 0; 0
+          Color Method: Object ID
+          Enabled: true
+          Name: Tracked Targets
+          Queue Size: 10
+          Scale: 0.4000000059604645
+          Shape: Sphere
+          Topic: /o79_udp/objects
+          Unreliable: false
+          Value: true
       Enabled: true
       Name: O-79 UDP
     - Class: rviz/Group
@@ -131,57 +124,54 @@ Visualization Manager:
           Unreliable: false
           Value: true
         - Alpha: 1
-          Class: ainstein_radar_rviz_plugins/RadarTargetArray
-          Color: 0; 0; 0
-          Color Method: Flat
+          Class: ainstein_radar_rviz_plugins/RadarTrackedObjectArray
+          Color: 255; 0; 0
+          Color Method: Object ID
           Enabled: true
-          Info Text Height: 0.05000000074505806
-          Max Range: 100
-          Min Range: 0
           Name: Tracked Targets
-          Number of Scans: 1
           Queue Size: 10
-          Scale: 0.5
+          Scale: 0.4000000059604645
           Shape: Sphere
-          Show Info: false
-          Show Speed: true
-          Topic: /o79_can/targets/tracked
+          Topic: /o79_can/objects
           Unreliable: false
           Value: true
       Enabled: true
       Name: O-79 CAN
-    - Alpha: 1
-      Arrow Length: 0.30000001192092896
-      Axes Length: 0.30000001192092896
-      Axes Radius: 0.009999999776482582
-      Class: rviz/PoseArray
-      Color: 255; 25; 0
-      Enabled: true
-      Head Length: 0.07000000029802322
-      Head Radius: 0.029999999329447746
-      Name: Cartesian_Objects_UDP
-      Queue Size: 10
-      Shaft Length: 0.23000000417232513
-      Shaft Radius: 0.009999999776482582
-      Shape: Arrow (Flat)
-      Topic: /o79_udp/poses
+    - Class: rviz/Camera
+      Enabled: false
+      Image Rendering: background and overlay
+      Image Topic: /usb_cam/image_raw
+      Name: Camera
+      Overlay Alpha: 0.5
+      Queue Size: 2
+      Transport Hint: raw
       Unreliable: false
-      Value: true
-    - Alpha: 1
-      Arrow Length: 0.30000001192092896
-      Axes Length: 0.30000001192092896
-      Axes Radius: 0.009999999776482582
-      Class: rviz/PoseArray
-      Color: 117; 80; 123
+      Value: false
+      Visibility:
+        Axes: true
+        Grid: true
+        Image: true
+        O-79 CAN:
+          Raw Targets: true
+          Tracked Targets: true
+          Value: true
+        O-79 UDP:
+          Bounding Boxes: true
+          Raw Targets: true
+          Tracked Targets: true
+          Value: true
+        Value: true
+      Zoom Factor: 1
+    - Class: rviz/Image
       Enabled: true
-      Head Length: 0.07000000029802322
-      Head Radius: 0.029999999329447746
-      Name: Cartesian_Objects_CAN
-      Queue Size: 10
-      Shaft Length: 0.23000000417232513
-      Shaft Radius: 0.009999999776482582
-      Shape: Arrow (Flat)
-      Topic: /o79_can/poses
+      Image Topic: /usb_cam/image_raw
+      Max Value: 1
+      Median window: 5
+      Min Value: 0
+      Name: Image
+      Normalize Range: true
+      Queue Size: 2
+      Transport Hint: raw
       Unreliable: false
       Value: true
   Enabled: true
@@ -212,7 +202,7 @@ Visualization Manager:
   Views:
     Current:
       Class: rviz/Orbit
-      Distance: 34.982486724853516
+      Distance: 23.496294021606445
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.05999999865889549
         Stereo Focal Distance: 1
@@ -228,17 +218,21 @@ Visualization Manager:
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Pitch: 1.5697963237762451
+      Pitch: 0.2797967493534088
       Target Frame: <Fixed Frame>
-      Yaw: 3.135399103164673
+      Yaw: 3.590397357940674
     Saved: ~
 Window Geometry:
+  Camera:
+    collapsed: false
   Displays:
     collapsed: false
-  Height: 1052
+  Height: 1025
   Hide Left Dock: false
   Hide Right Dock: true
-  QMainWindow State: 000000ff00000000fd0000000400000000000001ca0000037efc0200000008fb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d0000026f000000c900fffffffb0000001200530065006c0065006300740069006f006e01000002b2000001090000005c00fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f000002b0fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000003d000002b0000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000007380000003efc0100000002fb0000000800540069006d0065010000000000000738000002eb00fffffffb0000000800540069006d00650100000000000004500000000000000000000005680000037e00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Image:
+    collapsed: false
+  QMainWindow State: 000000ff00000000fd0000000400000000000001ca00000363fc020000000afb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d00000158000000c900fffffffb0000001200530065006c0065006300740069006f006e010000019b000000910000005c00fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000c00430061006d00650072006102000008710000021e000001ca00000094fb0000000a0049006d00610067006501000002320000016e0000001600ffffff000000010000010f000002b0fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000003d000002b0000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000007800000003efc0100000002fb0000000800540069006d0065010000000000000780000002eb00fffffffb0000000800540069006d00650100000000000004500000000000000000000005b00000036300000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Selection:
     collapsed: false
   Time:
@@ -247,6 +241,6 @@ Window Geometry:
     collapsed: false
   Views:
     collapsed: true
-  Width: 1848
-  X: 72
-  Y: 0
+  Width: 1920
+  X: 1920
+  Y: 27


### PR DESCRIPTION
USB cameras are often used alongside radar for testing and system development. Include a
launch file in this repo to make it more convenient to use them, even though they are
not part of the Ainstein RADAR family of devices.