### PR TITLE
Add range alert to Rviz plugin by scaling object

### DIFF
--- a/ainstein_radar_rviz_plugins/src/radar_tracked_object_array/radar_tracked_object_array_display.h
+++ b/ainstein_radar_rviz_plugins/src/radar_tracked_object_array/radar_tracked_object_array_display.h
@@ -50,6 +50,9 @@ namespace ainstein_radar_rviz_plugins
 
     // These Qt slots get connected to signals indicating changes in the user-editable properties.
     private Q_SLOTS:
+      void updateDisplayAlert();
+      void updateAlertScale();
+      void updateAlertRangeMax();
       void updateColorAndAlpha();
       void updateScale();
       void updateObjectShape();
@@ -64,6 +67,8 @@ namespace ainstein_radar_rviz_plugins
       // User-editable property variables.
       std::unique_ptr<rviz::ColorProperty> color_property_;
       std::unique_ptr<rviz::EnumProperty> color_method_property_;
+      std::unique_ptr<rviz::BoolProperty> display_alert_property_;
+      std::unique_ptr<rviz::Property> display_alert_options_property_;
       std::unique_ptr<rviz::FloatProperty> alpha_property_;
       std::unique_ptr<rviz::FloatProperty> scale_property_;
       std::unique_ptr<rviz::EnumProperty> shape_property_;

--- a/ainstein_radar_rviz_plugins/src/radar_tracked_object_array/radar_tracked_object_array_visual.cpp
+++ b/ainstein_radar_rviz_plugins/src/radar_tracked_object_array/radar_tracked_object_array_visual.cpp
@@ -101,6 +101,25 @@ void RadarTrackedObjectArrayVisual::setMessage( const ainstein_radar_msgs::Radar
                         obj.pose.orientation.y,
                         obj.pose.orientation.z ) );
 
+    radar_tracked_object_visuals_.back().pos.setScale( Ogre::Vector3( scale_, scale_, scale_ ) );
+    
+    // If display alert is true and the object is within the specified area,
+    // then scale it for visual effect:
+    if( display_alert_ )
+    {
+      // Convert from Cartesian to spherical coordinates:
+      double range = std::sqrt( std::pow( obj.pose.position.x, 2.0 ) +
+			 std::pow( obj.pose.position.y, 2.0 ) +
+			 std::pow( obj.pose.position.z, 2.0 ) );
+      double azimuth = std::atan2( obj.pose.position.y, obj.pose.position.x );
+      double elevation = std::asin( obj.pose.position.z / range );
+ 
+      if( range <= alert_range_max_ )
+      {
+        radar_tracked_object_visuals_.back().pos.setScale( Ogre::Vector3( alert_scale_, alert_scale_, alert_scale_ ) );
+      }
+    }
+
     // Define the velocity visual:
     double speed = std::sqrt( std::pow( obj.velocity.linear.x, 2.0 ) +
 			      std::pow( obj.velocity.linear.y, 2.0 ) +
@@ -210,10 +229,34 @@ void RadarTrackedObjectArrayVisual::setColor( int color_method, float r, float g
 // Scale is passed through to the Shape object.
 void RadarTrackedObjectArrayVisual::setScale( float scale )
 {
+  scale_ = scale;
   for( auto& v : radar_tracked_object_visuals_ )
     {
-      v.pos.setScale( Ogre::Vector3( scale, scale, scale ) );
+      v.pos.setScale( Ogre::Vector3( scale_, scale_, scale_ ) );
     }
+}
+
+void RadarTrackedObjectArrayVisual::setDisplayAlert( bool display_alert )
+{
+  display_alert_ = display_alert;
+}
+
+void RadarTrackedObjectArrayVisual::setAlertScale( float alert_scale )
+{
+  alert_scale_ = alert_scale;
+
+  if( display_alert_ )
+  {
+    for( auto& v : radar_tracked_object_visuals_ )
+      {
+        v.pos.setScale( Ogre::Vector3( alert_scale_, alert_scale_, alert_scale_ ) );
+      }
+  }
+}
+
+void RadarTrackedObjectArrayVisual::setAlertRangeMax( float alert_range_max )
+{
+  alert_range_max_ = alert_range_max;
 }
 
 } // namespace ainstein_radar_rviz_plugins

--- a/ainstein_radar_rviz_plugins/src/radar_tracked_object_array/radar_tracked_object_array_visual.h
+++ b/ainstein_radar_rviz_plugins/src/radar_tracked_object_array/radar_tracked_object_array_visual.h
@@ -34,7 +34,12 @@ public:
   {
     obj_shape_type_ = static_cast<rviz::Shape::Type>( type );
   }
-    
+
+  // Set whether to display an alert when the object is within a specified area:
+  void setDisplayAlert( bool display_alert );
+  void setAlertScale( float alert_scale );
+  void setAlertRangeMax( float alert_range_max );
+
   static const int max_radar_tracked_object_visuals;
   
 private:
@@ -47,6 +52,14 @@ private:
 
   // Shape to use for position rendering:
   rviz::Shape::Type obj_shape_type_;
+
+  // Nominal tracked object shape scale (size):
+  float scale_;
+
+  // Determined whether to display the object alert:
+  bool display_alert_;
+  float alert_scale_;
+  float alert_range_max_;
 };
  
 } // namespace ainstein_radar_rviz_plugins


### PR DESCRIPTION
This PR adds a simple visual indication ("alert") to the Rviz plugin for the RadarTrackedObjectArray message type when a tracked object crosses within a specified range threshold. The visual alert is achieved by scaling the object to a specified size while the alert condition is satisfied.

In order for the alert to be active, it must be enabled by checking the Display Alert checkbox in the plugin options. When enabled, the alert options are exposed to the user: these include the "Max Range" within which the alert is displayed, and the "Alert Scale" which sets the size of the object marker when the alert is active. When the alert's range condition is not satisfied, the object marker scale will be the value set in the normal Scale option. The alert works for both Flat and Object ID color modes.

See the following video for a brief demonstration of the plugin: https://drive.google.com/file/d/1sHZR9ZIiMqd9o3cf6SuHLBSvC6nKikag/view?usp=sharing

Note that the alert could easily be extended from a simple range threshold to an entire alert area of interest, specified by min/max range, azimuth, elevation, and even speed. The limits could alternatively be set in Cartesian coordinates if desired. This could be useful for testing the radar as a safety field sensor, for example.