### PR TITLE
Add min range and min/max elevation to visual alert

### DIFF
--- a/ainstein_radar_rviz_plugins/src/radar_tracked_object_array/radar_tracked_object_array_display.cpp
+++ b/ainstein_radar_rviz_plugins/src/radar_tracked_object_array/radar_tracked_object_array_display.cpp
@@ -69,9 +69,21 @@ namespace ainstein_radar_rviz_plugins
 						  "Object scale to be used when alert is active.",
 						  this, SLOT( updateAlertScale() ) ) );
 
-    display_alert_options_property_->addChild( new rviz::FloatProperty( "Max Range", 2.0,
+    display_alert_options_property_->addChild( new rviz::FloatProperty( "Min Range", 0.0,
+						  "Minimum range of alert area.",
+						  this, SLOT( updateAlertRangeMin() ) ) );
+
+    display_alert_options_property_->addChild( new rviz::FloatProperty( "Max Range", 100.0,
 						  "Maximum range of alert area.",
 						  this, SLOT( updateAlertRangeMax() ) ) );
+
+    display_alert_options_property_->addChild( new rviz::FloatProperty( "Min Elevation", -90.0,
+						  "Minimum elevation of alert area.",
+						  this, SLOT( updateAlertElevMin() ) ) );
+
+    display_alert_options_property_->addChild( new rviz::FloatProperty( "Max Elevation", 90.0,
+						  "Maximum elevation of alert area.",
+						  this, SLOT( updateAlertElevMax() ) ) );
 
     display_alert_options_property_->hide();
         
@@ -109,7 +121,10 @@ void RadarTrackedObjectArrayDisplay::onInitialize()
   updateScale();
   updateDisplayAlert();
   updateAlertScale();
+  updateAlertRangeMin();
   updateAlertRangeMax();
+  updateAlertElevMin();
+  updateAlertElevMax();
 }
 
 // Clear the visuals by deleting their objects.
@@ -143,13 +158,49 @@ void RadarTrackedObjectArrayDisplay::updateAlertScale()
   visual_->setAlertScale( scale );
 }
 
+// Set the alert area minimum range.
+void RadarTrackedObjectArrayDisplay::updateAlertRangeMin()
+{
+  // Set min range, checking that it is no greater than the current max range:
+  float range_min = std::min( static_cast<rviz::FloatProperty*>( display_alert_options_property_->subProp( "Min Range" ) )->getFloat(),
+			      static_cast<rviz::FloatProperty*>( display_alert_options_property_->subProp( "Max Range" ) )->getFloat() );
+  display_alert_options_property_->subProp( "Min Range" )->setValue( range_min );
+
+  visual_->setAlertRangeMin( range_min );
+}
+
+  
 // Set the alert area maximum range.
 void RadarTrackedObjectArrayDisplay::updateAlertRangeMax()
 {
-  // Set targets scale:
-  float range_max = static_cast<rviz::FloatProperty*>( display_alert_options_property_->subProp( "Max Range" ) )->getFloat();
+  // Set max range, checking that it is no less than the current min range:
+  float range_max = std::max( static_cast<rviz::FloatProperty*>( display_alert_options_property_->subProp( "Min Range" ) )->getFloat(),
+			      static_cast<rviz::FloatProperty*>( display_alert_options_property_->subProp( "Max Range" ) )->getFloat() );
+  display_alert_options_property_->subProp( "Max Range" )->setValue( range_max );
   
   visual_->setAlertRangeMax( range_max );
+}
+
+// Set the alert area minimum elevation.
+void RadarTrackedObjectArrayDisplay::updateAlertElevMin()
+{
+  // Set min elevation, checking that it is no greater than the current max elevation:
+  float elev_min = std::min( static_cast<rviz::FloatProperty*>( display_alert_options_property_->subProp( "Min Elevation" ) )->getFloat(),
+			     static_cast<rviz::FloatProperty*>( display_alert_options_property_->subProp( "Max Elevation" ) )->getFloat() );
+  display_alert_options_property_->subProp( "Min Elevation" )->setValue( elev_min );
+  
+  visual_->setAlertElevMin( elev_min );
+}
+
+// Set the alert area maximum elevation.
+void RadarTrackedObjectArrayDisplay::updateAlertElevMax()
+{
+  // Set max elevation, checking that it is no less than the current min elevation:
+  float elev_max = std::max( static_cast<rviz::FloatProperty*>( display_alert_options_property_->subProp( "Min Elevation" ) )->getFloat(),
+			     static_cast<rviz::FloatProperty*>( display_alert_options_property_->subProp( "Max Elevation" ) )->getFloat() );
+  display_alert_options_property_->subProp( "Max Elevation" )->setValue( elev_max );
+    
+  visual_->setAlertElevMax( elev_max );
 }
 
 // Set the current color and alpha values for each visual.

--- a/ainstein_radar_rviz_plugins/src/radar_tracked_object_array/radar_tracked_object_array_display.h
+++ b/ainstein_radar_rviz_plugins/src/radar_tracked_object_array/radar_tracked_object_array_display.h
@@ -52,7 +52,10 @@ namespace ainstein_radar_rviz_plugins
     private Q_SLOTS:
       void updateDisplayAlert();
       void updateAlertScale();
+      void updateAlertRangeMin();
       void updateAlertRangeMax();
+      void updateAlertElevMin();
+      void updateAlertElevMax();
       void updateColorAndAlpha();
       void updateScale();
       void updateObjectShape();

--- a/ainstein_radar_rviz_plugins/src/radar_tracked_object_array/radar_tracked_object_array_visual.cpp
+++ b/ainstein_radar_rviz_plugins/src/radar_tracked_object_array/radar_tracked_object_array_visual.cpp
@@ -114,7 +114,7 @@ void RadarTrackedObjectArrayVisual::setMessage( const ainstein_radar_msgs::Radar
       double azimuth = std::atan2( obj.pose.position.y, obj.pose.position.x );
       double elevation = std::asin( obj.pose.position.z / range );
  
-      if( range <= alert_range_max_ )
+      if( range >= alert_range_min_ && range <= alert_range_max_ && elevation >= alert_elev_min_ && elevation <= alert_elev_max_ )
       {
         radar_tracked_object_visuals_.back().pos.setScale( Ogre::Vector3( alert_scale_, alert_scale_, alert_scale_ ) );
       }
@@ -254,9 +254,24 @@ void RadarTrackedObjectArrayVisual::setAlertScale( float alert_scale )
   }
 }
 
+void RadarTrackedObjectArrayVisual::setAlertRangeMin( float alert_range_min )
+{
+  alert_range_min_ = alert_range_min;
+}
+
 void RadarTrackedObjectArrayVisual::setAlertRangeMax( float alert_range_max )
 {
   alert_range_max_ = alert_range_max;
+}
+
+void RadarTrackedObjectArrayVisual::setAlertElevMax( float alert_elev_max )
+{
+  alert_elev_max_ = alert_elev_max;
+}
+
+void RadarTrackedObjectArrayVisual::setAlertElevMin( float alert_elev_min )
+{
+  alert_elev_min_ = alert_elev_min;
 }
 
 } // namespace ainstein_radar_rviz_plugins

--- a/ainstein_radar_rviz_plugins/src/radar_tracked_object_array/radar_tracked_object_array_visual.h
+++ b/ainstein_radar_rviz_plugins/src/radar_tracked_object_array/radar_tracked_object_array_visual.h
@@ -38,7 +38,10 @@ public:
   // Set whether to display an alert when the object is within a specified area:
   void setDisplayAlert( bool display_alert );
   void setAlertScale( float alert_scale );
+  void setAlertRangeMin( float alert_range_min );
   void setAlertRangeMax( float alert_range_max );
+  void setAlertElevMin( float alert_elev_min );
+  void setAlertElevMax( float alert_elev_max );
 
   static const int max_radar_tracked_object_visuals;
   
@@ -59,7 +62,10 @@ private:
   // Determined whether to display the object alert:
   bool display_alert_;
   float alert_scale_;
+  float alert_range_min_;
   float alert_range_max_;
+  float alert_elev_min_;
+  float alert_elev_max_;
 };
  
 } // namespace ainstein_radar_rviz_plugins


### PR DESCRIPTION
# Summary
This small PR extends the existing visual alert from simply a maximum range to an area defined in polar coordinates by a min/max range and a min/max elevation. The user may not set inconsistent values for min/max, else their input is overridden and the value is clamped (for example, attempting to set a min range of 10 while the max range is 5 would clamp the min range to 5 for consistency).

# Testing
Testing is the same as described for the range-only alert in the previous PR; please see the video attached there. Tested and working on skid steer 2d tracked object data, however the elevation feature should be tested on data with elevation enabled (3d data); I could only test that setting the min/max to not include 0 degrees would cause the alert to disappear as expected.

# Notes
Note that the options for the visual alert are hidden until the user enables it in order to make the RViz display options less cluttered, however due to the way RViz handles hidden options, there appears to be some blank space in the options list. I do not know a fix for this, unfortunately. It does not affect performance, but makes the options list longer than necessary.