### PR TITLE
Add Camera Resolution Arguments

### DIFF
--- a/ainstein_radar_drivers/launch/usb_cam.launch
+++ b/ainstein_radar_drivers/launch/usb_cam.launch
@@ -1,6 +1,8 @@
 <launch>
   <!-- declare args to be passed in -->
   <arg name="cam_device" default="/dev/video1"/>
+  <arg name="img_width" default="320"/>
+  <arg name="img_height" default="240"/>
 
   <machine name="localhost" address="localhost" default="true" />
 
@@ -8,8 +10,8 @@
 
   <node machine="$(arg machine)" name="usb_cam" pkg="usb_cam" type="usb_cam_node" output="screen" required="false" >
     <param name="video_device" value="$(arg cam_device)" />
-    <param name="image_width" value="320" />
-    <param name="image_height" value="240" />
+    <param name="image_width" value="$(arg img_width)" />
+    <param name="image_height" value="$(arg img_height)" />
     <param name="framerate" value="10" />
     <param name="pixel_format" value="yuyv" />
     <param name="camera_frame_id" value="usb_cam" />


### PR DESCRIPTION
# Summary 

- This PR adds arguments for image_width and image_height in the usb_cam.launch file.
- Supports [PR#109 Camera Resolution Selection](https://github.com/AinsteinAI/O-79/pull/109) 