### PR TITLE
Parse 16 bit power in raw targets

### DIFF
--- a/ainstein_radar_drivers/include/ainstein_radar_drivers/radar_driver_o79_udp.h
+++ b/ainstein_radar_drivers/include/ainstein_radar_drivers/radar_driver_o79_udp.h
@@ -45,6 +45,7 @@ namespace ainstein_radar_drivers
     static const unsigned int msg_id_bounding_boxes;
     static const unsigned int msg_id_tracked_targets_cart;
     static const unsigned int msg_id_ground_targets_cart;
+    static const unsigned int msg_id_raw_targets_16bit_pwr;
 
     static const double msg_range_res;
     static const double msg_speed_res;

--- a/ainstein_radar_drivers/include/ainstein_radar_drivers/types_o79.h
+++ b/ainstein_radar_drivers/include/ainstein_radar_drivers/types_o79.h
@@ -1,0 +1,14 @@
+#ifndef types_o79_H_
+#define COMMON_H_
+
+typedef enum target_type {
+  no_type = -1,
+  raw_spherical = 0,
+  tracked_spherical = 1,
+  bounding_box = 2,
+  tracked_cartesian = 4,
+  ground_cartesian = 5,
+  raw_sphere_16bit_pwr = 6  
+} target_type_t;
+
+#endif


### PR DESCRIPTION
This is a new message type for both CAN and UDP.

Leave the snr member named as it is, instead of
changing it to power, because the Radar Target class
is used for multiple radars