### PR TITLE
Update o79.rviz camera topic from raw to compressed

### DIFF
--- a/ainstein_radar_drivers/rviz/o79.rviz
+++ b/ainstein_radar_drivers/rviz/o79.rviz
@@ -212,7 +212,7 @@ Visualization Manager:
       Name: Image
       Normalize Range: true
       Queue Size: 2
-      Transport Hint: raw
+      Transport Hint: compressed
       Unreliable: false
       Value: true
   Enabled: true


### PR DESCRIPTION
# Summary

- Modify transport hint for the `/usb_cam/image_raw` image topic from raw to compressed.
- Supports [PR#200](https://github.com/AinsteinAI/O-79/pull/200).