### PR TITLE
Support new msgType with varying CAN ID

### DIFF
--- a/ainstein_radar_drivers/include/ainstein_radar_drivers/types_o79.h
+++ b/ainstein_radar_drivers/include/ainstein_radar_drivers/types_o79.h
@@ -1,6 +1,8 @@
 #ifndef types_o79_H_
 #define COMMON_H_
 
+#define CAN_NUM_TRACK_CART_REV_C_PER_FRAME  10
+
 typedef enum radar_message_type {
   no_type = -1,
   raw_spherical = 0,
@@ -11,7 +13,8 @@ typedef enum radar_message_type {
   raw_sphere_16bit_pwr = 6,
   alarm_status = 7,
   filtered_point_cloud = 8,
-  tracked_cartesian_low_res = 9
+  tracked_cartesian_low_res = 9,
+  track_cart_rev_c = 10
 } radar_message_type_t;
 
 #endif

--- a/ainstein_radar_drivers/src/radar_interface_o79_can.cpp
+++ b/ainstein_radar_drivers/src/radar_interface_o79_can.cpp
@@ -92,12 +92,11 @@ namespace ainstein_radar_drivers
       if( msg.id == (can_id_ + i*(1 << 8)))
       {
         valid_CAN_ID = true;
-        if(i > 0)
+        if(target_type == no_type)
         {
-          /* PGN not default, but is valid, assume msgType */
           target_type = track_cart_rev_c;
         }
-        else
+        if(i == 0)
         {
           default_CAN_ID = true;
         }


### PR DESCRIPTION
Add support for new message type which will come with no header to identify it, and will have different CAN ID for each message in a frame