### PR TITLE
Add Support for Multiple Radars

### DIFF
--- a/ainstein_radar_drivers/launch/multi_radar_model.launch
+++ b/ainstein_radar_drivers/launch/multi_radar_model.launch
@@ -1,0 +1,16 @@
+<launch>
+
+  <arg name="model_path" default="$(find ainstein_radar_drivers)/urdf/multiple_radars.urdf"/>
+  <arg name="params_path" default="$(find ainstein_radar_drivers)/params/multiple_radars.yaml"/> 
+
+  <!-- Load the URDF for visualization and publish robot states -->
+  <param name="robot_description" command="$(find xacro)/xacro $(arg model_path) params_path:=$(arg params_path)" />
+  
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" >
+    <param name="publish_frequency" value="100" />
+  </node>
+
+  <!-- Run the map to base link and constrained DOFs publishers -->
+  <node name="map_to_base_link_broadcaster" pkg="tf" type="static_transform_publisher" args="0 0 0 0 0 0 map base_link 100" />
+  
+</launch>

--- a/ainstein_radar_drivers/launch/multi_radar_offline.launch
+++ b/ainstein_radar_drivers/launch/multi_radar_offline.launch
@@ -1,0 +1,18 @@
+<launch>
+
+  <!-- Rviz configuration. Change rviz file to support different visualization setups -->
+  <arg name="rvizconfig_multi_radar" default="$(find ainstein_radar_drivers)/rviz/o79_2_radars.rviz" />
+
+  <!-- Param required for playing back recorded data -->
+  <param name="use_sim_time" value="true" />
+
+  <!-- Machine model loading (needed for TF frames in visualization) -->
+  <include file="$(find ainstein_radar_drivers)/launch/multi_radar_model.launch" />
+
+  <!-- Run Rviz with specified configuration -->
+  <node name="rviz_multi_radar" pkg="rviz" type="rviz" args="-d $(arg rvizconfig_multi_radar)" />
+
+  <!-- Run the rqtbag GUI (make sure to right-click in bottom half and set to publish all) -->
+  <node name="rqt_bag" pkg="rqt_bag" type="rqt_bag" args="--clock" />
+
+</launch>

--- a/ainstein_radar_drivers/launch/o79_multiple_radars.launch
+++ b/ainstein_radar_drivers/launch/o79_multiple_radars.launch
@@ -1,0 +1,64 @@
+<launch>
+
+  <!-- Enable/Disable Sensors -->
+  <arg name="use_can" default="true" />
+  <arg name="use_udp" default="true" />
+  <arg name="use_camera" default="true" />
+
+  <!-- Radar model loading -->
+  <include file="$(find ainstein_radar_drivers)/launch/multi_radar_model.launch" />
+
+  <!-- Add additional radars to this file as needed. Make sure to update multiple_radars.yaml as well -->
+
+  <!-- O-79 CAN nodes -->
+  <group if="$(arg use_can)">
+
+    <!-- Run the 1st radar CAN node -->
+    <node name="radar1_o79_can" pkg="ainstein_radar_drivers" type="o79_can_node" output="screen" >
+      <param name="frame_id" value="radar1_link" />
+      <param name="can_id" value="0x18FFB24C" />
+    </node>
+    
+    <!-- Run the 2nd radar CAN node -->
+    <node name="radar2_o79_can" pkg="ainstein_radar_drivers" type="o79_can_node" output="screen" >
+      <param name="frame_id" value="radar2_link" />
+      <param name="can_id" value="0x18FFB24D" />
+    </node>
+
+  </group>
+
+  <!-- O-79 UDP nodes -->
+  <group if="$(arg use_udp)">
+
+    <!-- Run the 1st radar UDP node -->
+    <node name="radar1_o79_udp" pkg="ainstein_radar_drivers" type="o79_udp_node" output="screen" >
+      <param name="frame_id" value="radar1_link" />
+      <param name="host_ip" value="10.0.0.75" />
+      <param name="host_port" value="1024" />
+      <param name="radar_ip" value="10.0.0.10" />
+      <param name="radar_port" value="7" />
+    </node>
+
+    <!-- Run the 2nd radar UDP node -->
+    <node name="radar2_o79_udp" pkg="ainstein_radar_drivers" type="o79_udp_node" output="screen" >
+      <param name="frame_id" value="radar2_link" />
+      <param name="host_ip" value="10.0.0.75" />
+      <param name="host_port" value="1025" />
+      <param name="radar_ip" value="10.0.0.11" />
+      <param name="radar_port" value="7" />
+     </node>
+    
+  </group>
+
+  <!-- USB camera node -->
+  <group if="$(arg use_camera)">
+
+    <include file="$(find ainstein_radar_drivers)/launch/usb_cam.launch" >
+      <arg name="video_device" value="/dev/video2" />
+      <arg name="img_width" value="320"/>
+      <arg name="img_height" value="240"/>
+    </include>
+    
+  </group>
+  
+</launch>

--- a/ainstein_radar_drivers/params/multiple_radars.yaml
+++ b/ainstein_radar_drivers/params/multiple_radars.yaml
@@ -1,0 +1,32 @@
+# Specify number of radars, add details for each radar accordingly
+radar_qty: 2
+
+base_link:
+  mesh_fname: ""
+  mesh_scale: "1.0 1.0 1.0"
+
+radar1:
+  position: # coordinates in meters relative to the origin of the ROS coordinate system
+    x: 0
+    y: 0.5
+    z: 0.56
+  orientation: # roll, pitch, yaw in degrees
+    r: 0
+    p: -8
+    y: 15
+  mesh:
+    fname: "package://ainstein_radar_drivers/meshes/o79_v2.stl"
+    scale: "1.0 1.0 1.0"
+
+radar2:
+  position:
+    x: 0
+    y: -0.5
+    z: 0.56
+  orientation:
+    r: 0
+    p: -8
+    y: -15
+  mesh:
+    fname: "package://ainstein_radar_drivers/meshes/o79_v2.stl"
+    scale: "1.0 1.0 1.0"

--- a/ainstein_radar_drivers/rviz/o79_2_radars.rviz
+++ b/ainstein_radar_drivers/rviz/o79_2_radars.rviz
@@ -1,0 +1,412 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 0
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Radar UDP1
+        - /Radar UDP1/Radar11
+        - /Radar UDP1/Radar21
+        - /Radar CAN1
+      Splitter Ratio: 0.5020661354064941
+    Tree Height: 409
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Name: Time
+    SyncMode: 0
+    SyncSource: ""
+Preferences:
+  PromptSaveOnExit: true
+Toolbars:
+  toolButtonStyle: 2
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 1
+      Class: rviz/Axes
+      Enabled: true
+      Length: 0.5
+      Name: Axes
+      Radius: 0.05000000074505806
+      Reference Frame: <Fixed Frame>
+      Show Trail: false
+      Value: true
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 100
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Alpha: 1
+      Class: rviz/RobotModel
+      Collision Enabled: false
+      Enabled: true
+      Links:
+        All Links Enabled: true
+        Expand Joint Details: false
+        Expand Link Details: false
+        Expand Tree: false
+        Link Tree Style: Links in Alphabetic Order
+        base_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        radar1_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        radar2_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+      Name: RobotModel
+      Robot Description: robot_description
+      TF Prefix: ""
+      Update Interval: 0
+      Value: true
+      Visual Enabled: true
+    - Class: rviz/Group
+      Displays:
+        - Class: rviz/Group
+          Displays:
+            - Alpha: 1
+              Class: ainstein_radar_rviz_plugins/RadarTargetArray
+              Color: 255; 0; 0
+              Color Method: Flat
+              Enabled: false
+              Info Text Height: 0.05000000074505806
+              Max Range: 100
+              Min Range: 0
+              Name: Raw
+              Number of Scans: 1
+              Queue Size: 10
+              Scale: 0.10000000149011612
+              Shape: Cube
+              Show Info: false
+              Show Speed: true
+              Topic: /radar1_o79_udp/targets/raw
+              Unreliable: false
+              Value: false
+            - Alpha: 1
+              Class: ainstein_radar_rviz_plugins/RadarTargetArray
+              Color: 255; 0; 0
+              Color Method: Flat
+              Enabled: true
+              Info Text Height: 0.05000000074505806
+              Max Range: 100
+              Min Range: 0
+              Name: Filtered
+              Number of Scans: 1
+              Queue Size: 10
+              Scale: 0.20000000298023224
+              Shape: Sphere
+              Show Info: false
+              Show Speed: true
+              Topic: /radar1_o79_udp/targets/filtered
+              Unreliable: false
+              Value: true
+            - Alert Options:
+                Alert Scale: 1
+                Max Range: 2
+              Alert Scale: 1
+              Alpha: 1
+              Class: ainstein_radar_rviz_plugins/RadarTrackedObjectArray
+              Color: 255; 0; 0
+              Color Method: Object ID
+              Display Alert: false
+              Enabled: true
+              Max Range: 2
+              Name: Tracked
+              Queue Size: 10
+              Scale: 0.4000000059604645
+              Shape: Sphere
+              Topic: /radar1_o79_udp/objects
+              Unreliable: false
+              Value: true
+            - Alpha: 1
+              Class: ainstein_radar_rviz_plugins/BoundingBoxArray
+              Color: 255; 0; 0
+              Enabled: true
+              Name: BoundingBoxArray
+              Queue Size: 10
+              Topic: /radar1_o79_udp/boxes
+              Unreliable: false
+              Value: true
+            - Class: rviz/MarkerArray
+              Enabled: true
+              Marker Topic: /radar1_o79_udp/o79_udp/messages
+              Name: Messages
+              Namespaces:
+                {}
+              Queue Size: 100
+              Value: true
+          Enabled: true
+          Name: Radar1
+        - Class: rviz/Group
+          Displays:
+            - Alpha: 1
+              Class: ainstein_radar_rviz_plugins/RadarTargetArray
+              Color: 0; 0; 255
+              Color Method: Flat
+              Enabled: false
+              Info Text Height: 0.05000000074505806
+              Max Range: 100
+              Min Range: 0
+              Name: Raw
+              Number of Scans: 1
+              Queue Size: 10
+              Scale: 0.10000000149011612
+              Shape: Cube
+              Show Info: false
+              Show Speed: true
+              Topic: /radar2_o79_udp/targets/raw
+              Unreliable: false
+              Value: false
+            - Alpha: 1
+              Class: ainstein_radar_rviz_plugins/RadarTargetArray
+              Color: 0; 0; 255
+              Color Method: Flat
+              Enabled: true
+              Info Text Height: 0.05000000074505806
+              Max Range: 100
+              Min Range: 0
+              Name: Filtered
+              Number of Scans: 1
+              Queue Size: 10
+              Scale: 0.20000000298023224
+              Shape: Sphere
+              Show Info: false
+              Show Speed: true
+              Topic: /radar2_o79_can/targets/filtered
+              Unreliable: false
+              Value: true
+            - Alert Options:
+                Alert Scale: 1
+                Max Range: 2
+              Alert Scale: 1
+              Alpha: 1
+              Class: ainstein_radar_rviz_plugins/RadarTrackedObjectArray
+              Color: 255; 0; 0
+              Color Method: Object ID
+              Display Alert: false
+              Enabled: true
+              Max Range: 2
+              Name: Tracked
+              Queue Size: 10
+              Scale: 0.4000000059604645
+              Shape: Sphere
+              Topic: /radar2_o79_udp/objects
+              Unreliable: false
+              Value: true
+            - Alpha: 1
+              Class: ainstein_radar_rviz_plugins/BoundingBoxArray
+              Color: 255; 0; 0
+              Enabled: true
+              Name: BoundingBoxArray
+              Queue Size: 10
+              Topic: /radar2_o79_udp/boxes
+              Unreliable: false
+              Value: true
+            - Class: rviz/MarkerArray
+              Enabled: true
+              Marker Topic: /radar2_o79_udp/o79_udp/messages
+              Name: Messages
+              Namespaces:
+                {}
+              Queue Size: 100
+              Value: true
+          Enabled: true
+          Name: Radar2
+      Enabled: true
+      Name: Radar UDP
+    - Class: rviz/Group
+      Displays:
+        - Class: rviz/Group
+          Displays:
+            - Alpha: 1
+              Class: ainstein_radar_rviz_plugins/RadarTargetArray
+              Color: 255; 0; 0
+              Color Method: Flat
+              Enabled: false
+              Info Text Height: 0.05000000074505806
+              Max Range: 100
+              Min Range: 0
+              Name: Raw
+              Number of Scans: 1
+              Queue Size: 10
+              Scale: 0.10000000149011612
+              Shape: Cube
+              Show Info: false
+              Show Speed: false
+              Topic: /radar1_o79_can/targets/raw
+              Unreliable: false
+              Value: false
+            - Alert Options:
+                Alert Scale: 1
+                Max Range: 2
+              Alert Scale: 1
+              Alpha: 1
+              Class: ainstein_radar_rviz_plugins/RadarTrackedObjectArray
+              Color: 255; 0; 0
+              Color Method: Object ID
+              Display Alert: false
+              Enabled: true
+              Max Range: 2
+              Name: Tracked
+              Queue Size: 10
+              Scale: 0.4000000059604645
+              Shape: Sphere
+              Topic: /radar1_o79_can/objects
+              Unreliable: false
+              Value: true
+          Enabled: true
+          Name: Radar1
+        - Class: rviz/Group
+          Displays:
+            - Alpha: 1
+              Class: ainstein_radar_rviz_plugins/RadarTargetArray
+              Color: 0; 0; 255
+              Color Method: Flat
+              Enabled: false
+              Info Text Height: 0.05000000074505806
+              Max Range: 100
+              Min Range: 0
+              Name: Raw
+              Number of Scans: 1
+              Queue Size: 10
+              Scale: 0.20000000298023224
+              Shape: Cube
+              Show Info: false
+              Show Speed: false
+              Topic: /radar2_o79_can/targets/raw
+              Unreliable: false
+              Value: false
+            - Alert Options:
+                Alert Scale: 1
+                Max Range: 2
+              Alert Scale: 1
+              Alpha: 1
+              Class: ainstein_radar_rviz_plugins/RadarTrackedObjectArray
+              Color: 255; 0; 0
+              Color Method: Object ID
+              Display Alert: false
+              Enabled: true
+              Max Range: 2
+              Name: Tracked
+              Queue Size: 10
+              Scale: 0.4000000059604645
+              Shape: Sphere
+              Topic: /radar2_o79_can/objects
+              Unreliable: false
+              Value: true
+          Enabled: true
+          Name: Radar2
+      Enabled: true
+      Name: Radar CAN
+    - Class: rviz/Image
+      Enabled: true
+      Image Topic: /usb_cam/image_raw
+      Max Value: 1
+      Median window: 5
+      Min Value: 0
+      Name: USB Cam
+      Normalize Range: true
+      Queue Size: 2
+      Transport Hint: compressed
+      Unreliable: false
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 211; 215; 207
+    Default Light: true
+    Fixed Frame: map
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Theta std deviation: 0.2617993950843811
+      Topic: /initialpose
+      X std deviation: 0.5
+      Y std deviation: 0.5
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz/Orbit
+      Distance: 10.504607200622559
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Field of View: 0.7853981852531433
+      Focal Point:
+        X: 1.1815766096115112
+        Y: 0.008119253441691399
+        Z: 2.127764940261841
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.9997974634170532
+      Target Frame: <Fixed Frame>
+      Yaw: 3.147753953933716
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 1043
+  Hide Left Dock: false
+  Hide Right Dock: true
+  QMainWindow State: 000000ff00000000fd0000000400000000000001e600000353fc020000000efb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000005fb000001df00000185000000b0fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d000001d6000000c900fffffffb0000000e005500530042002000430061006d0100000219000001770000001600fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000a0049006d00610067006501000002ce000000d20000000000000000fb0000000a0049006d0061006700650100000258000001480000000000000000fb0000000a0049006d00610067006501000002d6000000c80000000000000000fb0000000c00430061006d0065007200610000000000ffffffff0000000000000000fb0000001a005500530042002000430061006d00200052006900670068007400000002a9000000ee0000000000000000000000010000010f00000363fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000003d00000363000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e100000197000000030000078000000060fc0100000002fb0000000800540069006d0065010000000000000780000003bc00fffffffb0000000800540069006d00650100000000000004500000000000000000000005940000035300000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  USB Cam:
+    collapsed: false
+  Views:
+    collapsed: true
+  Width: 1920
+  X: 0
+  Y: 0

--- a/ainstein_radar_drivers/urdf/multiple_radars.urdf
+++ b/ainstein_radar_drivers/urdf/multiple_radars.urdf
@@ -1,0 +1,78 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://ros.org/wiki/xacro" name="bobcat">
+
+  <!-- MATERIALS
+       Note: these are created using macros due to "multiple inclusion"
+       errors in xacro, which can be avoided in other ways if desired.
+  -->
+  <xacro:macro name="material_grey">
+    <material name="grey">
+      <color rgba="0.5 0.5 0.5 1.0"/>
+    </material>
+  </xacro:macro>
+
+  <xacro:macro name="material_dark_grey">
+    <material name="dark_grey">
+      <color rgba="0.15 0.15 0.15 1.0"/>
+    </material>
+  </xacro:macro>
+  
+
+  <!-- Need argument to get from launch file -->
+  <xacro:arg name="params_path" default="../params/2_radars.yaml"/> 
+
+  <!-- Need seperate property for xacro inorder processing -->
+  <xacro:property name="params_path" value="$(arg params_path)"/> 
+
+  <!-- Read in the yaml dict as mp (short for model parameters) -->
+  <xacro:property name="mp" value="${xacro.load_yaml(params_path)}"/> 
+
+
+  <!-- Macro to create radar link -->
+  <xacro:macro name="create_radar_link" params="name link_mp">
+    <link name="${name}_link">
+      <xacro:if value="${link_mp['mesh']['fname'] != ''}">
+        <visual>
+          <origin xyz="0 0 0" rpy="${0.0*pi} ${0.0*pi} ${0.0*pi}"/>
+          <geometry>
+            <mesh filename="${link_mp['mesh']['fname']}" scale="${link_mp['mesh']['scale']}"/>
+          </geometry>
+          <xacro:material_dark_grey />
+        </visual>
+      </xacro:if>
+    </link>
+    <joint name="${name}_joint" type="fixed">
+      <parent link="base_link"/>
+      <child link="${name}_link"/>
+      <origin xyz="${link_mp['position']['x']} ${link_mp['position']['y']} ${link_mp['position']['z']}" 
+              rpy="${link_mp['orientation']['r']*(pi/180.0)} ${link_mp['orientation']['p']*(pi/180.0)} ${link_mp['orientation']['y']*(pi/180.0)}" />
+    </joint>
+  </xacro:macro>
+
+  <!-- Macro to create multiple radar links -->
+  <xacro:macro name="radar_link_loop" params="links_qty">
+      <xacro:if value="${links_qty}">
+          <xacro:property name="link_name" value="radar${links_qty}"/> 
+          <xacro:create_radar_link name="${link_name}" link_mp="${mp[link_name]}"/>
+          <xacro:radar_link_loop links_qty="${links_qty-1}" />
+      </xacro:if>
+  </xacro:macro>
+  
+  <!--- BASE LINK -->
+  <link name="base_link">
+    <xacro:if value="${mp['base_link']['mesh_fname'] != ''}">
+      <visual>
+        <origin xyz="0 0 0" rpy="${0.5*pi} ${0.0*pi} ${0.0*pi}"/>
+        <geometry>
+          <mesh filename="${mp['base_link']['mesh_fname']}" 
+                scale="${mp['base_link']['mesh_scale']}"/>
+        </geometry>
+        <xacro:material_grey />
+      </visual>
+    </xacro:if>
+  </link>
+
+  <!-- RADAR LINKS -->
+  <xacro:radar_link_loop links_qty="${mp['radar_qty']}" />
+
+</robot>


### PR DESCRIPTION
# Summary

This PR adds support for visualizing and recording data with multiple radar nodes. The following files have been added to support this (no previous ainstein_radar code has been modified):

- `multi_radar_model.launch` : Loads the radar models
- `multiple_radars.urdf` : Defines the radar models geometry and organization
- `multiple_radars.yaml` : Settings for the radar models
- `o79_multiple_radars.launch` : Example launch file for running two O-79 radar nodes and a camera node
- `multi_radar_offline.launch` : Playback data using the multi radar model
- `o79_2_radars.rviz` : RViz configuration file to support running `o79_multiple_radars.launch`