### PR TITLE
Correct default CAN SA and CAN raw point PGN

### DIFF
--- a/ainstein_radar_drivers/launch/o79_can_node.launch
+++ b/ainstein_radar_drivers/launch/o79_can_node.launch
@@ -1,6 +1,6 @@
 <launch>
   <!-- declare args to be passed in -->
-  <arg name="can_id_arg" default="0x18FFB24D"/>
+  <arg name="can_id_arg" default="0x18FFB24C"/>
 
   <node name="socketcan_bridge" pkg="socketcan_bridge" type="socketcan_bridge_node"  required="true" >
     <param name="can_device" value="can0" />

--- a/ainstein_radar_drivers/src/radar_interface_o79_can.cpp
+++ b/ainstein_radar_drivers/src/radar_interface_o79_can.cpp
@@ -54,7 +54,7 @@ namespace ainstein_radar_drivers
     radar_info_msg_ptr_( new ainstein_radar_msgs::RadarInfo )
   {
     // Store the radar data frame ID:
-    nh_private_.param( "can_id", can_id_str_, std::string( "0x18FFB24D" ) );
+    nh_private_.param( "can_id", can_id_str_, std::string( "0x18FFB24C" ) );
     nh_private_.param( "frame_id", frame_id_, std::string( "map" ) );
 
     // Convert the CAN ID string to an int:

--- a/ainstein_radar_drivers/src/radar_interface_o79_can.cpp
+++ b/ainstein_radar_drivers/src/radar_interface_o79_can.cpp
@@ -75,6 +75,7 @@ namespace ainstein_radar_drivers
     can_frame_msg_.is_error = false;
     can_frame_msg_.dlc = 8;
   }
+  unsigned int raw_pt_can_id = std::stoul( std::string( "0x18FFA04C" ), nullptr, 16 );
 
   int targets_to_come = -1;
   unsigned int targets_received = 0;
@@ -97,6 +98,10 @@ namespace ainstein_radar_drivers
           starting_CAN_ID = true;
         }
         break;
+      }
+      else if( msg.id == (raw_pt_can_id))
+      {
+        valid_CAN_ID = true;
       }
     }
     if( valid_CAN_ID )


### PR DESCRIPTION
CAN raw points now are treated correctly when visualized in RViz, rather than trying to be interpreted as tracked targets. It also updates the default CAN SA to 4C to match the radar