### PR TITLE
Make SA a parameter of the o79_can driver

### DIFF
--- a/ainstein_radar_drivers/include/ainstein_radar_drivers/radar_interface_o79_can.h
+++ b/ainstein_radar_drivers/include/ainstein_radar_drivers/radar_interface_o79_can.h
@@ -80,9 +80,8 @@ namespace ainstein_radar_drivers
 
     can_msgs::Frame can_frame_msg_;
 
-    unsigned int can_id_;
     std::string frame_id_;
-    std::string can_id_str_;
+    std::string can_sa_str_;
 
     ros::Publisher pub_radar_info_;
     boost::shared_ptr<ainstein_radar_msgs::RadarInfo> radar_info_msg_ptr_;

--- a/ainstein_radar_drivers/launch/o79_can_node.launch
+++ b/ainstein_radar_drivers/launch/o79_can_node.launch
@@ -1,13 +1,13 @@
 <launch>
   <!-- declare args to be passed in -->
-  <arg name="can_id_arg" default="0x18FFB24C"/>
+  <arg name="can_sa_arg" default="4C"/>
 
   <node name="socketcan_bridge" pkg="socketcan_bridge" type="socketcan_bridge_node"  required="true" >
     <param name="can_device" value="can0" />
   </node>
 
   <node name="o79_can" pkg="ainstein_radar_drivers" type="o79_can_node" required="true" output="screen" >
-    <param name="can_id" value="$(arg can_id_arg)" />
+    <param name="can_sa" type="str" value="$(arg can_sa_arg)" />
   </node>
 
 </launch>


### PR DESCRIPTION
This fixes #37 by making the CAN source address, rather than an entire CAN ID, a parameter to the o79_can node. The source address parameter is concatenated to the base CAN ID's for tracked objects and point cloud points, so both are parsed correctly.