### PR TITLE
Updates to O-79-related code

### DIFF
--- a/ainstein_radar_drivers/launch/o79_playback.launch
+++ b/ainstein_radar_drivers/launch/o79_playback.launch
@@ -1,4 +1,5 @@
 <launch>
+  <arg name="launch_rviz" default="true" />
 
   <!-- Param required for playing back recorded data -->
   <param name="use_sim_time" value="true" />
@@ -6,8 +7,10 @@
   <!-- Load the rviz configuration -->
   <arg name="rvizconfig_o79" default="$(find ainstein_radar_drivers)/rviz/o79.rviz" />
 
-  <!-- Run Rviz with specified configuration -->
-  <node name="rviz_o79" pkg="rviz" type="rviz" args="-d $(arg rvizconfig_o79)" />
+  <group if="$(arg launch_rviz)">
+    <!-- Run Rviz with specified configuration -->
+    <node name="rviz_o79" pkg="rviz" type="rviz" args="-d $(arg rvizconfig_o79)" />
+  </group>
 
   <!-- Run the rqtbag GUI (make sure to right-click in bottom half and set to publish all) -->
   <node name="rqt_bag" pkg="rqt_bag" type="rqt_bag" args="--clock" />

--- a/ainstein_radar_drivers/launch/o79_playback.launch
+++ b/ainstein_radar_drivers/launch/o79_playback.launch
@@ -12,18 +12,4 @@
   <!-- Run the rqtbag GUI (make sure to right-click in bottom half and set to publish all) -->
   <node name="rqt_bag" pkg="rqt_bag" type="rqt_bag" args="--clock" />
 
-  <!-- Run ROS tracking filters on recorded raw UDP data -->
-  <!-- <include file="$(find ainstein_radar_drivers)/launch/ros_tracking_filter.launch" /> -->
-
-  <!-- Set whether to launch the online tuning GUI -->
-  <arg name="use_rqt_reconfigure" default="true" />
-
-  <group if="$(arg use_rqt_reconfigure)">
-    <!-- Run the rqt dynamic reconfiguration GUI to tune the trackers on recorded data -->
-    <node name="rqt_reconfigure" pkg="rqt_reconfigure" type="rqt_reconfigure" />
-  </group>
-
-    <!-- Run ROS point cloud debug node on recorded raw UDP data -->
-  <include file="$(find ainstein_radar_filters)/launch/o79_single_point_cloud_debug.launch" />
-
 </launch>

--- a/ainstein_radar_drivers/package.xml
+++ b/ainstein_radar_drivers/package.xml
@@ -22,7 +22,7 @@
   <depend>ainstein_radar_filters</depend>
   <depend>nodelet</depend>
   <depend>python-numpy-quaternion-pip</depend>
-
+  <depend>usb_cam</depend>
   
   <build_depend>message_generation</build_depend>
   <depend>std_msgs</depend>

--- a/ainstein_radar_drivers/rviz/o79.rviz
+++ b/ainstein_radar_drivers/rviz/o79.rviz
@@ -23,7 +23,6 @@ Panels:
     Name: Views
     Splitter Ratio: 0.5
   - Class: rviz/Time
-    Experimental: false
     Name: Time
     SyncMode: 0
     SyncSource: ""
@@ -67,7 +66,7 @@ Visualization Manager:
           Class: ainstein_radar_rviz_plugins/RadarTargetArray
           Color: 0; 0; 255
           Color Method: Flat
-          Enabled: false
+          Enabled: true
           Info Text Height: 0.05000000074505806
           Max Range: 100
           Min Range: 0
@@ -80,7 +79,7 @@ Visualization Manager:
           Show Speed: true
           Topic: /o79_udp/targets/raw
           Unreliable: false
-          Value: false
+          Value: true
         - Alpha: 1
           Class: ainstein_radar_rviz_plugins/RadarTargetArray
           Color: 0; 0; 255
@@ -126,32 +125,6 @@ Visualization Manager:
           Topic: /o79_udp/objects
           Unreliable: false
           Value: true
-        - Alert Options:
-            Alert Scale: 1
-            Max Range: 2
-          Alert Scale: 1
-          Alpha: 1
-          Class: ainstein_radar_rviz_plugins/RadarTrackedObjectArray
-          Color: 0; 0; 0
-          Color Method: Flat
-          Display Alert: false
-          Enabled: true
-          Max Range: 2
-          Name: Ground
-          Queue Size: 10
-          Scale: 0.30000001192092896
-          Shape: Sphere
-          Topic: /o79_udp/ground
-          Unreliable: false
-          Value: true
-        - Class: rviz/MarkerArray
-          Enabled: true
-          Marker Topic: /o79_udp/o79_udp/messages
-          Name: Messages
-          Namespaces:
-            {}
-          Queue Size: 100
-          Value: true
       Enabled: true
       Name: O-79 UDP
     - Class: rviz/Group
@@ -160,7 +133,7 @@ Visualization Manager:
           Class: ainstein_radar_rviz_plugins/RadarTargetArray
           Color: 255; 0; 0
           Color Method: Flat
-          Enabled: false
+          Enabled: true
           Info Text Height: 0.05000000074505806
           Max Range: 100
           Min Range: 0
@@ -173,7 +146,7 @@ Visualization Manager:
           Show Speed: true
           Topic: /o79_can/targets/raw
           Unreliable: false
-          Value: false
+          Value: true
         - Alpha: 1
           Class: ainstein_radar_rviz_plugins/RadarTargetArray
           Color: 255; 0; 0
@@ -212,35 +185,6 @@ Visualization Manager:
           Value: true
       Enabled: true
       Name: O-79 CAN
-    - Class: rviz/Camera
-      Enabled: false
-      Image Rendering: background and overlay
-      Image Topic: /usb_cam/image_raw
-      Name: Camera
-      Overlay Alpha: 0.5
-      Queue Size: 2
-      Transport Hint: raw
-      Unreliable: false
-      Value: false
-      Visibility:
-        Axes: true
-        Grid: true
-        Image: true
-        O-79 CAN:
-          Filtered Points: true
-          Raw Points: true
-          Tracked Objects: true
-          Value: true
-        O-79 UDP:
-          Bounding Boxes: true
-          Filtered Points: true
-          Ground: true
-          Messages: true
-          Raw Points: true
-          Tracked Objects: true
-          Value: true
-        Value: true
-      Zoom Factor: 1
     - Class: rviz/Image
       Enabled: true
       Image Topic: /usb_cam/image_raw
@@ -297,13 +241,11 @@ Visualization Manager:
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Pitch: 0.40979641675949097
+      Pitch: 0.4897962808609009
       Target Frame: <Fixed Frame>
-      Yaw: 3.245398998260498
+      Yaw: 2.860383987426758
     Saved: ~
 Window Geometry:
-  Camera:
-    collapsed: false
   Displays:
     collapsed: false
   Height: 1023
@@ -311,7 +253,7 @@ Window Geometry:
   Hide Right Dock: true
   Image:
     collapsed: false
-  QMainWindow State: 000000ff00000000fd0000000400000000000001ca00000361fc020000000afb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d000001fd000000c900fffffffb0000001200530065006c0065006300740069006f006e000000019a000000910000005c00fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000c00430061006d00650072006102000005000000021e00000280000001e0fb0000000a0049006d00610067006501000002400000015e0000001600ffffff000000010000010f000002b0fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000003d000002b0000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004f30000003efc0100000002fb0000000800540069006d00650100000000000004f3000002eb00fffffffb0000000800540069006d00650100000000000004500000000000000000000003230000036100000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  QMainWindow State: 000000ff00000000fd0000000400000000000001ca00000361fc020000000afb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d000001fd000000c900fffffffb0000001200530065006c0065006300740069006f006e000000019a000000910000005c00fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000c00430061006d00650072006102000005000000021e00000280000001e0fb0000000a0049006d00610067006501000002400000015e0000001600ffffff000000010000010f000002b0fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000003d000002b0000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004f30000003efc0100000002fb0000000800540069006d00650100000000000004f3000003bc00fffffffb0000000800540069006d00650100000000000004500000000000000000000003230000036100000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Selection:
     collapsed: false
   Time:
@@ -321,5 +263,5 @@ Window Geometry:
   Views:
     collapsed: true
   Width: 1267
-  X: 2061
-  Y: 27
+  X: 1077
+  Y: 48


### PR DESCRIPTION
- Remove the pcl_debugging feature from o79_playback
  - `rqt_bag` provides the same functionality
- Add an argument to o79_playback to either launch RViz or not
- Update default o79 rviz configuration
- Add `usb_cam` to the dependencies of `ainstein_radar_drivers` so the `usb_cam.launch` file works